### PR TITLE
minivold: Use libblkid for readMetadata

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -39,7 +39,8 @@ common_c_includes := \
 	frameworks/native/include \
 	system/security/keystore \
 	hardware/libhardware/include/hardware \
-	system/security/softkeymaster/include/keymaster
+	system/security/softkeymaster/include/keymaster \
+	external/e2fsprogs/lib
 
 common_libraries := \
 	libsysutils \


### PR DESCRIPTION
We cannot popen() /sbin/blkid because selinux.

Change-Id: I0ba032c362dcfaa72443860071e5bd4d4d3b8270